### PR TITLE
Close the unterminated L<> markup on the gdImageRed link

### DIFF
--- a/lib/GD/Raw.rakumod
+++ b/lib/GD/Raw.rakumod
@@ -780,7 +780,7 @@ L<C<gdImageSY>|https://libgd.github.io/manuals/2.3.3/files/gd-h.html#gdImageSY>
 
 L<C<gdImageColorsTotal>|https://libgd.github.io/manuals/2.3.3/files/gd-h.html#gdImageColorsTotal>
 
-L<C<gdImageRed>|https://libgd.github.io/manuals/2.3.3/files/gd-h.html#gdImageRed
+L<C<gdImageRed>|https://libgd.github.io/manuals/2.3.3/files/gd-h.html#gdImageRed>
 
 L<C<gdImageGreen>|https://libgd.github.io/manuals/2.3.3/files/gd-h.html#gdImageGreen>
 


### PR DESCRIPTION
The gdImageRed entry was missing the closing > on its L<...> link. The legacy pod parser tolerated this by consuming the following link's >. RakuDoc under RakuAST correctly rejects the unterminated markup with "RakuDoc markup code L missing endtag '>'", so the module fails to compile there. Add the missing >.